### PR TITLE
Fix:		Attribute Error on MacOS

### DIFF
--- a/spygame/__init__.py
+++ b/spygame/__init__.py
@@ -293,7 +293,7 @@ class KeyboardInputs(EventObject):
         events = pygame.event.get([pygame.KEYDOWN, pygame.KEYUP])
         for e in events:
             # a key was pressed that we are interested in -> set to True or False
-            if e.key in self.keyboard_registry:
+            if getattr(e, 'key', None) in self.keyboard_registry:
                 if e.type == pygame.KEYDOWN:
                     self.keyboard_registry[e.key] = True
                     self.trigger_event("key_down." + self.descriptions[e.key])


### PR DESCRIPTION
This minor change fixes an issue (at least on MacOS) that pygame does return empty Events even when waiting for keyboard events.